### PR TITLE
Allow repeated applications of `filtered`, `matching`, and `mapWith`

### DIFF
--- a/checkmate.nix
+++ b/checkmate.nix
@@ -54,9 +54,19 @@ in
           ];
         };
 
+        matching."test `filter` composes with `matching`" = {
+          expr = ((lit.matching ".*/[^/]+_[^/]+\.nix").filtered (lib.hasSuffix "b.nix")).leafs ./tree;
+          expected = [ ./tree/a/a_b.nix ];
+        };
+
         mapWith."test transforms each matching file with function" = {
           expr = (lit.mapWith import).leafs ./tree/x;
           expected = [ "z" ];
+        };
+
+        mapWith."test multiple `mapWith`s compose" = {
+          expr = ((lit.mapWith import).mapWith builtins.stringLength).leafs ./tree/x;
+          expected = [ 1 ];
         };
 
         pipeTo."test pipes list into a function" = {


### PR DESCRIPTION
This PR makes the `filtered`, `matching`, and `mapWith` functions composable, such that when applied repeatedly, they combine their effects instead of overriding the previous applications.

I've updated the README to showcase a few examples, and added test cases for the new functionality.

I've also done some minor improvements to the code, e.g. removed the call to `lib.toList` (because `flatten` already does that if its input isn't a list), and replaced `lib` functions with their `builtins` equivalents (where applicable).