### PR TITLE
feat: Compose import-tree by juxtaposition (inspired by denful/ned)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,8 +8,8 @@ ci:
   just test
 
 fmt *args:
-  nix run github:denful/checkmate#fmt --override-input target path:. {{args}}
+  nix run github:denful/checkmate#fmt --override-input target path:. -L {{args}}
 
 test *args:
-  nix flake check github:denful/checkmate --override-input target . {{args}}
+  nix flake check github:denful/checkmate --override-input target . -L {{args}}
 

--- a/checkmate/modules/tests.nix
+++ b/checkmate/modules/tests.nix
@@ -270,6 +270,11 @@ in
             }).config.foo;
           expected = 22;
         };
+
+        combinator."test combinator syntax to compose import-tree" = {
+          expr = it (it: it.withLib lib) (it: it.leafs) ../tree/_scoped;
+          expected = [ ../tree/_scoped/foo.nix ];
+        };
       };
 
     }

--- a/default.nix
+++ b/default.nix
@@ -23,19 +23,21 @@ let
       # module exists so we delay access to lib til we are part of the module system.
       module =
         { lib, ... }:
+        let
+          files = leafs lib path;
+          imports = if scoped == { } then files else map scoped-import files;
+        in
         {
-          imports = (if scoped == { } then leafs else scoped-leafs) lib path;
+          inherit imports;
         };
 
-      scoped-leafs =
-        lib: root:
-        map (builtins.scopedImport (
-          {
-            inherit builtins;
-            __nixPath = [ ];
-          }
-          // scoped
-        )) (leafs lib root);
+      scoped-import = builtins.scopedImport (
+        {
+          inherit builtins;
+          __nixPath = [ ];
+        }
+        // scoped
+      );
 
       leafs =
         lib:
@@ -145,7 +147,12 @@ let
 
   inModuleEval = and (x: x ? options) builtins.isAttrs;
 
-  functor = self: arg: perform self.__config (if inModuleEval arg then [ ] else arg);
+  functor =
+    self: arg:
+    if builtins.isFunction arg && builtins.functionArgs arg == { } then
+      arg self # arg is a combinator pass the self import-tree obj
+    else
+      perform self.__config (if inModuleEval arg then [ ] else arg);
 
   callable =
     let


### PR DESCRIPTION
This adds the following juxtaposition syntax for combining:

```nix
import-tree (it: it.addScoped x) (it: it.addAPI y) (it: it.addScoped z) ./modules
```

previously we only had the builder pattern which requires more parens

```nix
(((import-tree.addScoped x).addAPI y).addScoped z) ./modules
```

both work now.

--

This is inspired on how streams compose at [denful/ned](https://github.com/denful/ned)